### PR TITLE
Fix large file upload issue

### DIFF
--- a/photoslibraryapi/src/main/java/com/google/photos/library/v1/upload/PhotosLibraryUploadCallable.java
+++ b/photoslibraryapi/src/main/java/com/google/photos/library/v1/upload/PhotosLibraryUploadCallable.java
@@ -243,7 +243,7 @@ final class PhotosLibraryUploadCallable implements Callable<UploadMediaItemRespo
 
     switch (response.getFirstHeader(UPLOAD_STATUS_HEADER).getValue()) {
       case UploadStatuses.ACTIVE:
-        return Integer.parseInt(response.getFirstHeader(RECEIVED_BYTE_COUNT_HEADER).getValue());
+        return Long.parseLong(response.getFirstHeader(RECEIVED_BYTE_COUNT_HEADER).getValue());
       case UploadStatuses.FINAL:
         return request.getFileSize();
       default:


### PR DESCRIPTION
If I try to upload a large file (file size > Integer.MAX_SIZE), I get a NumberFormatException from the updated line.
Changing the Integer.parseInt to a Long.parseLong solves the problem.