### PR TITLE
Fix broken release page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To use this library with Maven, add the following to your Maven `pom.xml` file:
 ```
 
 ### Option 3: Download a release
-The [releases page](releases/) contains different artifacts for each library release, including jar files.
+The [releases page](https://github.com/google/java-photoslibrary/releases) contains different artifacts for each library release, including jar files.
 
 ### Option 4: Clone the repository
 
@@ -129,7 +129,7 @@ for any other API questions, bug reports, or feature requests.
 
 For general Google Photos Library API and client library updates and news, follow:
 
-* [Java client library release notes](releases/)
+* [Java client library release notes](https://github.com/google/java-photoslibrary/releases)
 * [Google Photos Library API release notes](https://developers.google.com/photos/library/support/release-notes)
 
 ## License


### PR DESCRIPTION
The release page links in the README.md leads to 404 Not Found Error Page.  
At the moment it looks like this:
Line#41: [releases page](releases/)
Line#132: * [Java client library release notes](releases/)


Proposed fix: 
Line#41: [releases page](https://github.com/google/java-photoslibrary/releases)
Line#132: * [Java client library release notes](https://github.com/google/java-photoslibrary/releases)