### PR TITLE
"Duplicate photo entries" issue resolved

### DIFF
--- a/photoslibraryapi/src/main/java/com/google/photos/library/v1/upload/UploadMediaItemRequest.java
+++ b/photoslibraryapi/src/main/java/com/google/photos/library/v1/upload/UploadMediaItemRequest.java
@@ -119,13 +119,13 @@ public final class UploadMediaItemRequest {
 
     public Builder mergeFrom(UploadMediaItemRequest other) {
 
-      if (!other.getFileName().isEmpty()) {
+      if (!other.getFileName().isPresent()) {
         fileName = other.fileName;
       }
-      if (!other.getMimeType().isEmpty()) {
+      if (!other.getMimeType().isPresent()) {
         mimeType = other.mimeType;
       }
-      if (!other.getUploadUrl().isEmpty()) {
+      if (!other.getUploadUrl().isPresent()) {
         uploadUrl = other.uploadUrl;
       }
       chunkSize = other.getChunkSize();

--- a/sample/src/main/java/com/google/photos/library/sample/demos/upload/tasks/ByteUploadTask.java
+++ b/sample/src/main/java/com/google/photos/library/sample/demos/upload/tasks/ByteUploadTask.java
@@ -103,7 +103,7 @@ public class ByteUploadTask implements Callable<ByteUploadTask.ByteUploadResult>
       // Upload the bytes and capture the response from the API.
       UploadMediaItemResponse uploadResponse = photosLibraryClient.uploadMediaItem(uploadRequest);
 
-      if (uploadResponse.getUploadToken().isPresent() && uploadResponse.getError().isEmpty()) {
+      if (uploadResponse.getUploadToken().isPresent() && uploadResponse.getError().isPresent()) {
         // The upload was successful, because an upload token is present and there was no error.
         final String uploadToken = uploadResponse.getUploadToken().get();
         return ByteUploadResult.createSuccessResult(fileToUpload, uploadToken);


### PR DESCRIPTION
The root cause of the issue is actually due to the improper usage of Photos Client in "sample" folder. The Google Photos library client is perfectly working fine.

I have resolved this issue by updating the un-existing method's references(isEmpty()) with the existing method's references(isPresent()) (in the classes committed as part of this pull request) whose method definition is available. I have confirmed it by using my Google Photos account which has 468 sample images and the issue isn't prevailing now. PFB the screenshot.

![fig 7](https://user-images.githubusercontent.com/37448485/206919905-3f73e085-f086-4e7a-a8b9-7c158e6e3e86.jpg)



